### PR TITLE
MINV-15: Add Merge Conflict PR Workflow

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,0 +1,13 @@
+name: 'Check for Merge Conflicts'
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: 'has conflicts'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR verifies that PRs are not dirty (no merge conflicts). A 'has conflicts' label is added to the PR if there are merge conflicts, and then removed once remedied.